### PR TITLE
Performance improvements

### DIFF
--- a/hdf5/inMemoryIMS_hdf5.py
+++ b/hdf5/inMemoryIMS_hdf5.py
@@ -36,25 +36,19 @@ class inMemoryIMS_hdf5():
             if len(mzs) != len(counts):
                 raise TypeError('length of mzs ({}) not equal to counts ({})'.format(len(mzs),len(counts)))
             # Enforce data limits
-            mz_range = [m>min_mz and m<max_mz for m in mzs]  
-            counts=counts[np.where(mz_range)] #using mz_range as a boolean index failed - just returned the first value over and over
-            mzs=mzs[np.where(mz_range)]
-            ct_gt0 = counts>min_int
-            mzs = mzs[np.where(ct_gt0)]
-            counts=counts[np.where(ct_gt0)]
+            valid = np.where((mzs>min_mz) & (mzs<max_mz) & (counts > min_int))
+            counts=counts[valid]
+            mzs=mzs[valid]
 
             # append ever-growing lists (should probably be preallocated or piped to disk and re-loaded)
-            for a in list(mzs):
-                self.mz_list.append(a)
-            for c in list(counts):
-                self.count_list.append(c)
-            for ix in ii*np.ones((len(mzs),),dtype =int):
-                self.idx_list.append(ix)
+            self.mz_list.append(mzs)
+            self.count_list.append(counts)
+            self.idx_list.append(np.ones(len(mzs), dtype=int) * ii)
             
         print 'loaded spectra'
-        self.mz_list = np.asarray(self.mz_list)
-        self.count_list = np.asarray(self.count_list)
-        self.idx_list = np.asarray(self.idx_list)
+        self.mz_list = np.concatenate(self.mz_list)
+        self.count_list = np.concatenate(self.count_list)
+        self.idx_list = np.concatenate(self.idx_list)
         # sort by mz for fast image formation
         mz_order = np.argsort(self.mz_list)
         self.mz_list = self.mz_list[mz_order]

--- a/hdf5/inMemoryIMS_hdf5.py
+++ b/hdf5/inMemoryIMS_hdf5.py
@@ -84,14 +84,13 @@ class inMemoryIMS_hdf5():
             tols = tols*mzs/1e6 # to m/z
         data_out = ion_datacube()
         data_out.add_coords(self.coords)
-        for mz,tol in zip(mzs,tols):
-            mz_upper = mz + tol
-            mz_lower = mz - tol
-            idx_left = bisect.bisect_left(self.mz_list,mz_lower)
-            idx_right = bisect.bisect_right(self.mz_list,mz_upper)
+
+        idx_left = np.searchsorted(self.mz_list, mzs - tols, 'l')
+        idx_right = np.searchsorted(self.mz_list, mzs + tols, 'r')
+        for mz,tol,il,ir in zip(mzs,tols,idx_left,idx_right):
             # slice list for code clarity
-            count_vect = np.concatenate((np.asarray([0]),self.count_list[idx_left:idx_right],np.asarray([0])))
-            idx_vect = np.concatenate((np.asarray([0]),self.idx_list[idx_left:idx_right],np.asarray([max(self.index_list)])))
+            count_vect = np.concatenate((np.asarray([0]),self.count_list[il:ir],np.asarray([0])))
+            idx_vect = np.concatenate((np.asarray([0]),self.idx_list[il:ir],np.asarray([max(self.index_list)])))
             # bin vectors
             ion_vect=np.bincount(idx_vect,count_vect)
             data_out.add_xic(ion_vect,[mz],[tol])

--- a/image_measures/isotope_pattern_match.py
+++ b/image_measures/isotope_pattern_match.py
@@ -10,7 +10,7 @@ def isotope_pattern_match(images,theoretical_isotope_intensity):
     import numpy as np
     from scipy import ndimage, misc, ndarray, interpolate 
 
-    image_intensities = [sum(images[ii]) for ii in range(0,len(theoretical_isotope_intensity))]
+    image_intensities = [np.sum(images[ii]) for ii in range(0,len(theoretical_isotope_intensity))]
     isotope_pattern_match = 1-np.mean(abs(theoretical_isotope_intensity/np.linalg.norm(theoretical_isotope_intensity) - image_intensities/np.linalg.norm(image_intensities)))    
     return isotope_pattern_match 
 

--- a/ion_datacube.py
+++ b/ion_datacube.py
@@ -53,14 +53,12 @@ class ion_datacube():
             else:
                 step=params[0]
             # coordinate to pixels
-            for c in range(0,len(_coord)):
-                for ii in range(0,3):
-                    _coord[c,ii] = _coord[c,ii]/step[ii]
+            _coord /= np.reshape(step, (3,))
             _coord_max = np.amax(_coord,axis=0)
             self.nColumns = _coord_max[1]+1
             self.nRows = _coord_max[0]+1            
-            for c in range(0,len(_coord)): #to vector index, rowmajor
-                 pixel_indices[c] = _coord[c,0]*(self.nColumns) + _coord[c,1]            
+            pixel_indices = _coord[:,0] * self.nColumns + _coord[:,1]
+            pixel_indices = pixel_indices.astype(np.int32)
         else:
             print 'transform type not recognised'
             raise ValueError
@@ -68,9 +66,7 @@ class ion_datacube():
     def xic_to_image(self,xic_index):
         xic = self.xic[xic_index]
         # turn xic into an image
-        img = np.zeros((self.nRows*self.nColumns,1))
-        for n in range(0,len(self.pixel_indices)):
-            img[self.pixel_indices[n]] = xic[n]
-    
+        img = np.zeros(self.nRows*self.nColumns)
+        img[self.pixel_indices] = xic
         img=np.reshape(img,(self.nRows,self.nColumns))
         return img


### PR DESCRIPTION
Hi Andy,

I replaced most loops with vectorized `numpy` operations, and made a few other small fixes. I haven't changed any algorithms, it's just a smarter use of `numpy` and precalculating pixel indices as they are the same for each datacube.

Also, measure of chaos now attempts to use functions from OpenCV if it's installed (latest version 3.0 is needed, because `cv2.connectedComponents` was added not long ago), it runs ~5x faster with it.
(On Mac, you should be able to simply grab `opencv3` bottle from `homebrew/science`.)
