### PR TITLE
Fix search

### DIFF
--- a/hdf5/inMemoryIMS_hdf5.py
+++ b/hdf5/inMemoryIMS_hdf5.py
@@ -68,7 +68,7 @@ class inMemoryIMS_hdf5():
 
         # split binary searches into two stages for better locality
         self.window_size = 1024
-        self.mz_sublist = self.mz_list[::self.window_size]
+        self.mz_sublist = self.mz_list[::self.window_size].copy()
 
         print 'file loaded'
 


### PR DESCRIPTION
Hi Andy,

This PR
- restores old search behavior, which was correct (`[il:ir]` instead of `[il:ir-1]`)
- splits each binary search into two stages; first it looks for windows of length 1024, and then performs binary search within the found windows. The effect is much fewer cache misses.
